### PR TITLE
Bump Textual Template Engine version

### DIFF
--- a/Data/Settings/styleSettings.plist
+++ b/Data/Settings/styleSettings.plist
@@ -22,7 +22,7 @@
 	<key>Template Engine Versions</key>
 	<dict>
 		<key>default</key>
-		<integer>3</integer>
+		<integer>4</integer>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Bump the Template Engine Versions to `4` for compatibility with Textual 7.